### PR TITLE
fix(updater): refresh update_core transient before find_core_update

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -107,6 +107,25 @@ class Updater {
 			require_once ABSPATH . 'wp-admin/includes/misc.php';
 		}
 
+		// Refresh WordPress's cached core-update offer before resolving
+		// the target. The `update_core` site transient can be stale —
+		// most importantly right after a rollback: that rollback request
+		// rebuilt the transient from a stale wp_get_wp_version() (a
+		// per-request static the Core_Upgrader cannot change in-process),
+		// so it still advertises the previous version with
+		// response='latest'. find_core_update() would then return that
+		// offer and Core_Upgrader rejects the upgrade as "WordPress is
+		// at the latest version.". This call runs in a fresh request, so
+		// wp_get_wp_version() now reports the real current version —
+		// deleting the transient and forcing wp_version_check() rebuilds
+		// a correct offer, so the update succeeds on the first attempt.
+		// Skipped for the downgrade path, which installs its own
+		// doctored offer via the pre_site_transient_update_core filter.
+		if ( empty( $args['skip_core_check'] ) ) {
+			delete_site_transient( 'update_core' );
+			wp_version_check( [], true );
+		}
+
 		$update = find_core_update( $args['version'], $args['locale'] );
 		if ( ! $update ) {
 			return [
@@ -305,8 +324,12 @@ class Updater {
 		//    the rewritten offer and Core_Upgrader runs with no
 		//    special casing.
 		$result = $this->core_updater( [
-			'version' => $target_version,
-			'locale'  => $args['locale'],
+			'version'         => $target_version,
+			'locale'          => $args['locale'],
+			// Downgrade already deletes the transient and installs its
+			// own rewritten offer via filters — a forced wp_version_check
+			// in core_updater() would just be a wasted remote call.
+			'skip_core_check' => true,
 		] );
 
 		// 8. Always tear down our filters.


### PR DESCRIPTION
## Problem

After a core **rollback**, the next core **update** failed on its first attempt with *"WordPress is at the latest version."* and only succeeded on a retry.

## Root cause

The rollback request rebuilds the `update_core` site transient via `wp_version_check()`. But `wp_version_check()` reads the version from `wp_get_wp_version()` — a **per-request `static`** that `Core_Upgrader` cannot refresh in-process. So during the rollback request the transient is rebuilt with the *pre-rollback* version and still advertises `response='latest'`. The subsequent update's `find_core_update()` returns that stale offer and `Core_Upgrader` rejects it as `up_to_date`.

## Fix

In `core_updater()`, **before `find_core_update()`**, delete the `update_core` transient and force `wp_version_check()`. This runs in a fresh request where `wp_get_wp_version()` reports the real current version, so a correct offer is rebuilt and the update succeeds on the first attempt.

The downgrade path passes `skip_core_check=true` since `core_downgrade()` installs its own doctored offer via the `pre_site_transient_update_core` filter.

## Testing

Verified on connected dev sites: rollback → update now works on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)