### PR TITLE
fix: don't treat a conditionally-defined constant as global wp-config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+v1.1.3
+======
+- Fixed: Config Manager no longer reports a constant whose `define()` sits inside a conditional block (e.g. the InstaCache `if ( WP_CLI )` guard) as global wp-config, and no longer rewrites or removes one.
+- Fixed: `WP_REDIS_*` object-cache config is excluded from Config Manager reads and writes, so saving a setting can no longer corrupt the Valkey ACL password.
+- Added: `set()`/`delete()` return a `skipped` list naming the constants that were protected, so a caller can tell a save apart from a silent no-op.
+
 v1.1.2
 ======
 - Added: Migration engine detection (v3/v4) via `getMigrationEngine()`.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "instawp/connect-helpers",
     "description": "CLI Package for InstaWP Remote Features",
     "type": "library",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "license": "MIT",
     "authors": [
         {

--- a/src/WPConfig.php
+++ b/src/WPConfig.php
@@ -152,6 +152,17 @@ class WPConfig extends \WPConfigTransformer {
                     continue;
                 }
 
+                /* A close tag ends the statement exactly like a semicolon, so a brace-less
+                   body such as `if ( $a ) define( 'X', 1 ) ?>` must not leave the header
+                   open over the constants that follow it. */
+                if ( T_CLOSE_TAG === $id ) {
+                    $header  = null;
+                    $keyword = null;
+                    $expects_colon    = false;
+                    $condition_closed = false;
+                    continue;
+                }
+
                 if ( in_array( $id, $end_keywords, true ) ) {
                     array_pop( $stack );
                     $expects_colon = false;
@@ -373,7 +384,7 @@ class WPConfig extends \WPConfigTransformer {
      * @return bool
      */
     protected function is_define_call( $tokens, $index ) {
-        $rejected = [ T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION ];
+        $rejected = [ T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_NS_SEPARATOR ];
 
         if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
             $rejected[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
@@ -429,7 +440,9 @@ class WPConfig extends \WPConfigTransformer {
      *
      * The test is deliberately narrow: merely mentioning the name is not enough, or
      * `if ( getenv( 'WP_DEBUG' ) === 'yes' ) { define( 'WP_DEBUG', true ); }` — a genuinely
-     * conditional define — would be waved through as global config.
+     * conditional define — would be waved through as global config. It is not exhaustive
+     * either: a self-guard ANDed with another test (`if ( ! defined( 'FS_METHOD' ) && ! WP_CLI )`)
+     * still counts as a guard, which under-detects in the same direction as before this change.
      *
      * @param array  $headers
      * @param string $name

--- a/src/WPConfig.php
+++ b/src/WPConfig.php
@@ -97,8 +97,16 @@ class WPConfig extends \WPConfigTransformer {
      * `if ( ! defined( 'FOO' ) ) { define( 'FOO', ... ); }` idempotency guard — is
      * unconditional in effect, so it stays manageable.
      *
-     * Known limitation: a nested define() is only detected where the tokenizer is
-     * available; without it nothing is filtered and behaviour is unchanged.
+     * Deliberate limitations, all of which fail towards today's behaviour rather than
+     * towards hiding a constant that is genuinely global:
+     *  - Without the tokenizer extension nothing is filtered at all.
+     *  - The result is keyed by NAME, so a constant defined both at the top level and
+     *    inside a block is left alone entirely. That is intentional: the transformer
+     *    rewrites by matching source text and we cannot tell which occurrence it would
+     *    edit, so refusing is the only safe answer.
+     *  - A brace-less body that immediately opens another statement
+     *    (`if ( $a )` newline `if ( ! defined( 'FOO' ) ) { ... }`) is judged on the inner
+     *    condition only; tracking the outer one needs statement-level parsing.
      *
      * @param string $src wp-config.php source.
      *
@@ -158,7 +166,13 @@ class WPConfig extends \WPConfigTransformer {
                     continue;
                 }
 
-                if ( in_array( $id, $scope_keywords, true ) ) {
+                // A control keyword only opens a scope at the top of a statement. Inside
+                // parentheses it belongs to something else — a closure in a condition — and
+                // must not replace the header being read. PHP 7 also allows reserved words as
+                // member names, so `function for( $k ): string` still lexes T_FOR: taking that
+                // as a `for` header would read its return-type ':' as alternative syntax and
+                // push a scope nothing pops.
+                if ( in_array( $id, $scope_keywords, true ) && 0 === $paren && ! $this->is_member_name( $tokens, $index ) ) {
                     $header  = $text;
                     $keyword = $id;
                     // `else` takes no condition, so its alternative-syntax ':' comes next.
@@ -210,6 +224,17 @@ class WPConfig extends \WPConfigTransformer {
             }
 
             if ( '{' === $token ) {
+                // A '{' inside parentheses is a closure or match body sitting in the middle of
+                // a condition — `if ( array_filter( $a, function ( $v ) { … } ) ) :`. It opens a
+                // scope, but the header it interrupts is still being read, so keep it: nulling
+                // it would stop the following ':' from pushing and leave the matching `endif`
+                // to pop the enclosing block instead.
+                if ( $paren > 0 ) {
+                    $stack[] = '';
+                    $expects_colon = false;
+                    continue;
+                }
+
                 $stack[] = ( null === $header ) ? '' : $header;
                 $header  = null;
                 $keyword = null;
@@ -313,6 +338,32 @@ class WPConfig extends \WPConfigTransformer {
     }
 
     /**
+     * Whether the token at $index is being used as a member/function NAME rather than as
+     * the keyword it lexes to. PHP 7 allows reserved words after `function`, `->`, `?->`
+     * and `::`, so `function for( $k )` and `$obj->if()` both reach us as control keywords.
+     *
+     * @param array $tokens
+     * @param int   $index
+     *
+     * @return bool
+     */
+    protected function is_member_name( $tokens, $index ) {
+        $before = $this->next_significant( $tokens, $index, -1 );
+
+        if ( null === $before || ! is_array( $tokens[ $before ] ) ) {
+            return false;
+        }
+
+        $names_follow = [ T_FUNCTION, T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_CONST ];
+
+        if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
+            $names_follow[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
+        }
+
+        return in_array( $tokens[ $before ][0], $names_follow, true );
+    }
+
+    /**
      * Whether the `define` token at $index is a real function call and not a method
      * name (`$obj->define(...)`, `Foo::define(...)`) or a declaration.
      *
@@ -372,9 +423,13 @@ class WPConfig extends \WPConfigTransformer {
     }
 
     /**
-     * Whether every enclosing condition names the constant itself, i.e. the define() is
-     * only wrapped in its own `if ( ! defined( 'FOO' ) )` guard and therefore applies
-     * unconditionally.
+     * Whether every enclosing condition is a `defined( 'FOO' )` test on the constant
+     * itself, i.e. the define() is only wrapped in its own idempotency guard and therefore
+     * applies unconditionally.
+     *
+     * The test is deliberately narrow: merely mentioning the name is not enough, or
+     * `if ( getenv( 'WP_DEBUG' ) === 'yes' ) { define( 'WP_DEBUG', true ); }` — a genuinely
+     * conditional define — would be waved through as global config.
      *
      * @param array  $headers
      * @param string $name
@@ -386,8 +441,10 @@ class WPConfig extends \WPConfigTransformer {
             return true;
         }
 
+        $pattern = '/\bdefined\s*\(\s*[\'"]' . preg_quote( $name, '/' ) . '[\'"]\s*\)/';
+
         foreach ( $headers as $header ) {
-            if ( ! preg_match( '/\b' . preg_quote( $name, '/' ) . '\b/', $header ) ) {
+            if ( ! preg_match( $pattern, $header ) ) {
                 return false;
             }
         }
@@ -476,9 +533,14 @@ class WPConfig extends \WPConfigTransformer {
                 continue;
             }
 
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || $this->is_blacklisted( $key ) || isset( $scoped[ $key ] ) ) ) {
-                // Report what was not written. The caller posts the whole constant map back,
-                // so without this a protected constant looks saved and silently reverts.
+            if ( ! $this->is_cli && preg_match( '/[a-z]/', $key ) ) {
+                // Not a constant name we ever manage — a malformed key, not a protection.
+                continue;
+            }
+
+            if ( ! $this->is_cli && ( $this->is_blacklisted( $key ) || isset( $scoped[ $key ] ) ) ) {
+                // Report what was deliberately not written. The caller posts the whole constant
+                // map back, so without this a protected constant looks saved and silently reverts.
                 $skipped[] = $key;
                 continue;
             }

--- a/src/WPConfig.php
+++ b/src/WPConfig.php
@@ -49,6 +49,265 @@ class WPConfig extends \WPConfigTransformer {
         return false;
     }
 
+    /**
+     * Control structures whose body we treat as a conditional scope.
+     *
+     * @return array
+     */
+    protected function scope_keywords() {
+        $keywords = [ T_IF, T_ELSEIF, T_ELSE, T_WHILE, T_FOR, T_FOREACH, T_SWITCH, T_DO, T_TRY, T_CATCH, T_FUNCTION ];
+
+        foreach ( [ 'T_FINALLY', 'T_FN', 'T_MATCH' ] as $maybe ) {
+            if ( defined( $maybe ) ) {
+                $keywords[] = constant( $maybe );
+            }
+        }
+
+        return $keywords;
+    }
+
+    /**
+     * Control structures that support PHP's alternative (colon) syntax.
+     *
+     * Deliberately excludes T_FUNCTION so a return type (`function f(): void`) is not
+     * mistaken for the start of a block.
+     *
+     * @return array
+     */
+    protected function alternative_syntax_keywords() {
+        return [ T_IF, T_ELSEIF, T_ELSE, T_WHILE, T_FOR, T_FOREACH, T_SWITCH ];
+    }
+
+    /**
+     * Names of constants whose define() does NOT sit at the top level of wp-config.php.
+     *
+     * WPConfigTransformer parses wp-config.php with a flat regex that has no awareness of
+     * enclosing scope, so a define() nested in a block — for example the InstaCache
+     * drop-in's
+     *
+     *     if ( defined( 'WP_CLI' ) && WP_CLI ) {
+     *         define( 'WP_REDIS_DISABLED', true );
+     *     }
+     *
+     * — is reported exactly like a top-level one. Surfacing such a constant to the Config
+     * Manager is wrong twice over: it advertises a value that does not apply to ordinary
+     * requests, and saving it back rewrites code inside a branch the caller never saw.
+     *
+     * A define() whose every enclosing condition names the constant itself — the ordinary
+     * `if ( ! defined( 'FOO' ) ) { define( 'FOO', ... ); }` idempotency guard — is
+     * unconditional in effect, so it stays manageable.
+     *
+     * Known limitation: a nested define() is only detected where the tokenizer is
+     * available; without it nothing is filtered and behaviour is unchanged.
+     *
+     * @param string $src wp-config.php source.
+     *
+     * @return array Constant name => true.
+     */
+    protected function scoped_constants( $src ) {
+        if ( ! function_exists( 'token_get_all' ) ) {
+            return [];
+        }
+
+        $tokens = @token_get_all( $src );
+
+        if ( empty( $tokens ) ) {
+            return [];
+        }
+
+        $scope_keywords = $this->scope_keywords();
+        $alt_keywords   = $this->alternative_syntax_keywords();
+        $end_keywords   = [ T_ENDIF, T_ENDWHILE, T_ENDFOR, T_ENDFOREACH, T_ENDSWITCH ];
+
+        $scoped  = [];
+        $stack   = [];   // One entry per open block: the header text that introduced it.
+        $header  = null; // Header text of the control structure currently being read.
+        $keyword = null; // Which keyword started that header.
+        $paren   = 0;    // Parenthesis depth, so a ternary ':' is not read as a block opener.
+        $total   = count( $tokens );
+
+        for ( $index = 0; $index < $total; $index++ ) {
+            $token = $tokens[ $index ];
+
+            if ( is_array( $token ) ) {
+                $id   = $token[0];
+                $text = $token[1];
+
+                if ( in_array( $id, $end_keywords, true ) ) {
+                    array_pop( $stack );
+                    continue;
+                }
+
+                // A '{' that opens string interpolation ("{$a}", "${a}") is closed by a plain
+                // '}', so it has to be balanced here or every later define() looks nested.
+                if ( T_CURLY_OPEN === $id || T_DOLLAR_OPEN_CURLY_BRACES === $id ) {
+                    $stack[] = '';
+                    continue;
+                }
+
+                if ( in_array( $id, $scope_keywords, true ) ) {
+                    $header  = $text;
+                    $keyword = $id;
+                    continue;
+                }
+
+                if ( T_STRING === $id && 0 === strcasecmp( $text, 'define' ) && $this->is_define_call( $tokens, $index ) ) {
+                    // Inside a block, or a brace-less body such as `if ( ... ) define( ... );`.
+                    if ( ! empty( $stack ) || null !== $header ) {
+                        $enclosing = $stack;
+                        if ( null !== $header ) {
+                            $enclosing[] = $header;
+                        }
+
+                        $name = $this->define_name( $tokens, $index );
+
+                        if ( '' !== $name && ! $this->guards_itself( $enclosing, $name ) ) {
+                            $scoped[ $name ] = true;
+                        }
+                    }
+                    continue;
+                }
+
+                if ( null !== $header ) {
+                    $header .= $text;
+                }
+
+                continue;
+            }
+
+            if ( '(' === $token ) {
+                $paren++;
+            } elseif ( ')' === $token ) {
+                $paren--;
+            }
+
+            if ( '{' === $token ) {
+                $stack[] = ( null === $header ) ? '' : $header;
+                $header  = null;
+                $keyword = null;
+                continue;
+            }
+
+            if ( '}' === $token ) {
+                array_pop( $stack );
+                continue;
+            }
+
+            if ( ':' === $token && null !== $header && 0 === $paren && in_array( $keyword, $alt_keywords, true ) ) {
+                $stack[] = $header;
+                $header  = null;
+                $keyword = null;
+                continue;
+            }
+
+            if ( ';' === $token && 0 === $paren ) {
+                // The statement ended without opening a block (a brace-less body, or `do ... while;`).
+                $header  = null;
+                $keyword = null;
+                continue;
+            }
+
+            if ( null !== $header ) {
+                $header .= $token;
+            }
+        }
+
+        return $scoped;
+    }
+
+    /**
+     * Whether the `define` token at $index is a real function call and not a method
+     * name (`$obj->define(...)`, `Foo::define(...)`) or a declaration.
+     *
+     * @param array $tokens
+     * @param int   $index
+     *
+     * @return bool
+     */
+    protected function is_define_call( $tokens, $index ) {
+        for ( $before = $index - 1; $before >= 0; $before-- ) {
+            $token = $tokens[ $before ];
+
+            if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
+                continue;
+            }
+
+            if ( is_array( $token ) && in_array( $token[0], [ T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION ], true ) ) {
+                return false;
+            }
+
+            break;
+        }
+
+        for ( $after = $index + 1; $after < count( $tokens ); $after++ ) {
+            $token = $tokens[ $after ];
+
+            if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
+                continue;
+            }
+
+            return '(' === $token;
+        }
+
+        return false;
+    }
+
+    /**
+     * The constant name of the define() call whose `define` token sits at $index.
+     *
+     * @param array $tokens
+     * @param int   $index
+     *
+     * @return string Empty when the name is not a plain string literal.
+     */
+    protected function define_name( $tokens, $index ) {
+        $total = count( $tokens );
+
+        for ( $next = $index + 1; $next < $total; $next++ ) {
+            $token = $tokens[ $next ];
+
+            if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
+                continue;
+            }
+
+            if ( '(' === $token ) {
+                continue;
+            }
+
+            if ( is_array( $token ) && T_CONSTANT_ENCAPSED_STRING === $token[0] ) {
+                return trim( $token[1], "'\"" );
+            }
+
+            return '';
+        }
+
+        return '';
+    }
+
+    /**
+     * Whether every enclosing condition names the constant itself, i.e. the define() is
+     * only wrapped in its own `if ( ! defined( 'FOO' ) )` guard and therefore applies
+     * unconditionally.
+     *
+     * @param array  $headers
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function guards_itself( $headers, $name ) {
+        if ( empty( $headers ) ) {
+            return true;
+        }
+
+        foreach ( $headers as $header ) {
+            if ( ! preg_match( '/\b' . preg_quote( $name, '/' ) . '\b/', $header ) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function __construct( array $constants = [], $is_cli = false, $read_only = false ) {
         $file = ABSPATH . 'wp-config.php';
         if ( ! file_exists( $file ) ) {
@@ -81,8 +340,10 @@ class WPConfig extends \WPConfigTransformer {
             'wp-config' => [],
         ];
 
+        $scoped = $this->is_cli ? [] : $this->scoped_constants( $this->wp_config_src );
+
         foreach ( $this->wp_configs['constant'] as $constant => $data ) {
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $constant ) || $this->is_blacklisted( $constant ) ) ) {
+            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $constant ) || $this->is_blacklisted( $constant ) || isset( $scoped[ $constant ] ) ) ) {
                 continue;
             }
 
@@ -120,12 +381,14 @@ class WPConfig extends \WPConfigTransformer {
             $args['placement'] = 'after';
         }
 
+        $scoped = $this->is_cli ? [] : $this->scoped_constants( $content );
+
         foreach ( $this->config_data as $key => $value ) {
             if ( empty( $key ) ) {
                 continue;
             }
 
-            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || $this->is_blacklisted( $key ) ) ) {
+            if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || $this->is_blacklisted( $key ) || isset( $scoped[ $key ] ) ) ) {
                 continue;
             }
 
@@ -173,7 +436,21 @@ class WPConfig extends \WPConfigTransformer {
             throw new \Exception( 'No constants provided!' );
         }
 
+        $scoped = [];
+
+        if ( ! $this->is_cli ) {
+            $content = file_get_contents( $this->wp_config_path );
+            $scoped  = $this->scoped_constants( $content );
+        }
+
         foreach ( $constants as $constant ) {
+            // Same protection get()/set() apply: the Config Manager never removes a
+            // blacklisted (platform-managed) constant, nor one that only exists inside a
+            // conditional block it was never able to show the caller.
+            if ( ! $this->is_cli && ( $this->is_blacklisted( $constant ) || isset( $scoped[ $constant ] ) ) ) {
+                continue;
+            }
+
             try {
                 $this->remove( 'constant', $constant );
             } catch ( \Exception $e ) {

--- a/src/WPConfig.php
+++ b/src/WPConfig.php
@@ -119,11 +119,15 @@ class WPConfig extends \WPConfigTransformer {
         $alt_keywords   = $this->alternative_syntax_keywords();
         $end_keywords   = [ T_ENDIF, T_ENDWHILE, T_ENDFOR, T_ENDFOREACH, T_ENDSWITCH ];
 
+        $trivia = [ T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ];
+
         $scoped  = [];
         $stack   = [];   // One entry per open block: the header text that introduced it.
         $header  = null; // Header text of the control structure currently being read.
         $keyword = null; // Which keyword started that header.
         $paren   = 0;    // Parenthesis depth, so a ternary ':' is not read as a block opener.
+        $expects_colon = false; // We are exactly at the ':' position of alternative syntax.
+        $condition_closed = false; // The current header's own condition has been closed.
         $total   = count( $tokens );
 
         for ( $index = 0; $index < $total; $index++ ) {
@@ -133,25 +137,37 @@ class WPConfig extends \WPConfigTransformer {
                 $id   = $token[0];
                 $text = $token[1];
 
+                if ( in_array( $id, $trivia, true ) ) {
+                    if ( null !== $header ) {
+                        $header .= $text;
+                    }
+                    continue;
+                }
+
                 if ( in_array( $id, $end_keywords, true ) ) {
                     array_pop( $stack );
+                    $expects_colon = false;
                     continue;
                 }
 
                 // A '{' that opens string interpolation ("{$a}", "${a}") is closed by a plain
                 // '}', so it has to be balanced here or every later define() looks nested.
                 if ( T_CURLY_OPEN === $id || T_DOLLAR_OPEN_CURLY_BRACES === $id ) {
-                    $stack[] = '';
+                    $stack[]       = '';
+                    $expects_colon = false;
                     continue;
                 }
 
                 if ( in_array( $id, $scope_keywords, true ) ) {
                     $header  = $text;
                     $keyword = $id;
+                    // `else` takes no condition, so its alternative-syntax ':' comes next.
+                    $expects_colon    = ( T_ELSE === $id );
+                    $condition_closed = ( T_ELSE === $id );
                     continue;
                 }
 
-                if ( T_STRING === $id && 0 === strcasecmp( $text, 'define' ) && $this->is_define_call( $tokens, $index ) ) {
+                if ( $this->is_define_token( $token ) && $this->is_define_call( $tokens, $index ) ) {
                     // Inside a block, or a brace-less body such as `if ( ... ) define( ... );`.
                     if ( ! empty( $stack ) || null !== $header ) {
                         $enclosing = $stack;
@@ -165,6 +181,7 @@ class WPConfig extends \WPConfigTransformer {
                             $scoped[ $name ] = true;
                         }
                     }
+                    $expects_colon = false;
                     continue;
                 }
 
@@ -172,31 +189,53 @@ class WPConfig extends \WPConfigTransformer {
                     $header .= $text;
                 }
 
+                $expects_colon = false;
                 continue;
             }
 
             if ( '(' === $token ) {
                 $paren++;
+                $expects_colon = false;
             } elseif ( ')' === $token ) {
                 $paren--;
+                // Only the ':' immediately after a control structure's OWN closing ')' opens an
+                // alternative-syntax block — hence $condition_closed, which stops a later call
+                // in a brace-less body from re-arming it. Without this, the ':' of a ternary
+                // (`if ( $a ) $b = $c ? d( $e ) : f();`) pushes a scope that nothing pops, and
+                // every constant below it in the file silently disappears.
+                if ( 0 === $paren && null !== $header && ! $condition_closed ) {
+                    $expects_colon    = true;
+                    $condition_closed = true;
+                }
             }
 
             if ( '{' === $token ) {
                 $stack[] = ( null === $header ) ? '' : $header;
                 $header  = null;
                 $keyword = null;
+                $expects_colon    = false;
+                $condition_closed = false;
                 continue;
             }
 
             if ( '}' === $token ) {
                 array_pop( $stack );
+                $expects_colon = false;
                 continue;
             }
 
-            if ( ':' === $token && null !== $header && 0 === $paren && in_array( $keyword, $alt_keywords, true ) ) {
+            if ( ':' === $token && $expects_colon && null !== $header && 0 === $paren && in_array( $keyword, $alt_keywords, true ) ) {
+                // `elseif:` / `else:` continue the same if-chain that a single `endif` closes,
+                // so they replace the open scope rather than nesting inside it.
+                if ( T_ELSEIF === $keyword || T_ELSE === $keyword ) {
+                    array_pop( $stack );
+                }
+
                 $stack[] = $header;
                 $header  = null;
                 $keyword = null;
+                $expects_colon    = false;
+                $condition_closed = false;
                 continue;
             }
 
@@ -204,15 +243,73 @@ class WPConfig extends \WPConfigTransformer {
                 // The statement ended without opening a block (a brace-less body, or `do ... while;`).
                 $header  = null;
                 $keyword = null;
+                $expects_colon    = false;
+                $condition_closed = false;
                 continue;
             }
 
             if ( null !== $header ) {
                 $header .= $token;
             }
+
+            if ( ')' !== $token ) {
+                $expects_colon = false;
+            }
         }
 
         return $scoped;
+    }
+
+    /**
+     * Whether a token names the `define` function, in either the plain (`define`) or
+     * fully qualified (`\define`) form. PHP 8 lexes the latter as a single token.
+     *
+     * @param array|string $token
+     *
+     * @return bool
+     */
+    protected function is_define_token( $token ) {
+        if ( ! is_array( $token ) ) {
+            return false;
+        }
+
+        $ids = [ T_STRING ];
+
+        if ( defined( 'T_NAME_FULLY_QUALIFIED' ) ) {
+            $ids[] = constant( 'T_NAME_FULLY_QUALIFIED' );
+        }
+
+        if ( ! in_array( $token[0], $ids, true ) ) {
+            return false;
+        }
+
+        return 0 === strcasecmp( ltrim( $token[1], '\\' ), 'define' );
+    }
+
+    /**
+     * Index of the next token after $index that is not whitespace or a comment.
+     *
+     * @param array $tokens
+     * @param int   $index
+     * @param int   $step   1 to scan forwards, -1 to scan backwards.
+     *
+     * @return int|null
+     */
+    protected function next_significant( $tokens, $index, $step = 1 ) {
+        $trivia = [ T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ];
+        $total  = count( $tokens );
+
+        for ( $cursor = $index + $step; $cursor >= 0 && $cursor < $total; $cursor += $step ) {
+            $token = $tokens[ $cursor ];
+
+            if ( is_array( $token ) && in_array( $token[0], $trivia, true ) ) {
+                continue;
+            }
+
+            return $cursor;
+        }
+
+        return null;
     }
 
     /**
@@ -225,31 +322,21 @@ class WPConfig extends \WPConfigTransformer {
      * @return bool
      */
     protected function is_define_call( $tokens, $index ) {
-        for ( $before = $index - 1; $before >= 0; $before-- ) {
-            $token = $tokens[ $before ];
+        $rejected = [ T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION ];
 
-            if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
-                continue;
-            }
-
-            if ( is_array( $token ) && in_array( $token[0], [ T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION ], true ) ) {
-                return false;
-            }
-
-            break;
+        if ( defined( 'T_NULLSAFE_OBJECT_OPERATOR' ) ) {
+            $rejected[] = constant( 'T_NULLSAFE_OBJECT_OPERATOR' );
         }
 
-        for ( $after = $index + 1; $after < count( $tokens ); $after++ ) {
-            $token = $tokens[ $after ];
+        $before = $this->next_significant( $tokens, $index, -1 );
 
-            if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
-                continue;
-            }
-
-            return '(' === $token;
+        if ( null !== $before && is_array( $tokens[ $before ] ) && in_array( $tokens[ $before ][0], $rejected, true ) ) {
+            return false;
         }
 
-        return false;
+        $after = $this->next_significant( $tokens, $index );
+
+        return null !== $after && '(' === $tokens[ $after ];
     }
 
     /**
@@ -261,27 +348,27 @@ class WPConfig extends \WPConfigTransformer {
      * @return string Empty when the name is not a plain string literal.
      */
     protected function define_name( $tokens, $index ) {
-        $total = count( $tokens );
+        $open = $this->next_significant( $tokens, $index );
 
-        for ( $next = $index + 1; $next < $total; $next++ ) {
-            $token = $tokens[ $next ];
-
-            if ( is_array( $token ) && T_WHITESPACE === $token[0] ) {
-                continue;
-            }
-
-            if ( '(' === $token ) {
-                continue;
-            }
-
-            if ( is_array( $token ) && T_CONSTANT_ENCAPSED_STRING === $token[0] ) {
-                return trim( $token[1], "'\"" );
-            }
-
+        if ( null === $open || '(' !== $tokens[ $open ] ) {
             return '';
         }
 
-        return '';
+        $literal = $this->next_significant( $tokens, $open );
+
+        if ( null === $literal || ! is_array( $tokens[ $literal ] ) || T_CONSTANT_ENCAPSED_STRING !== $tokens[ $literal ][0] ) {
+            return '';
+        }
+
+        // The literal must BE the whole first argument: `define( 'PRE' . $suffix, 1 )` would
+        // otherwise register 'PRE' and hide a genuinely top-level define( 'PRE', ... ).
+        $separator = $this->next_significant( $tokens, $literal );
+
+        if ( null === $separator || ',' !== $tokens[ $separator ] ) {
+            return '';
+        }
+
+        return trim( $tokens[ $literal ][1], "'\"" );
     }
 
     /**
@@ -381,7 +468,8 @@ class WPConfig extends \WPConfigTransformer {
             $args['placement'] = 'after';
         }
 
-        $scoped = $this->is_cli ? [] : $this->scoped_constants( $content );
+        $scoped  = $this->is_cli ? [] : $this->scoped_constants( $content );
+        $skipped = [];
 
         foreach ( $this->config_data as $key => $value ) {
             if ( empty( $key ) ) {
@@ -389,6 +477,9 @@ class WPConfig extends \WPConfigTransformer {
             }
 
             if ( ! $this->is_cli && ( preg_match( '/[a-z]/', $key ) || $this->is_blacklisted( $key ) || isset( $scoped[ $key ] ) ) ) {
+                // Report what was not written. The caller posts the whole constant map back,
+                // so without this a protected constant looks saved and silently reverts.
+                $skipped[] = $key;
                 continue;
             }
 
@@ -426,7 +517,13 @@ class WPConfig extends \WPConfigTransformer {
             }
         }
 
-        return [ 'success' => true ];
+        $response = [ 'success' => true ];
+
+        if ( ! empty( $skipped ) ) {
+            $response['skipped'] = $skipped;
+        }
+
+        return $response;
     }
 
     public function delete() {
@@ -443,11 +540,14 @@ class WPConfig extends \WPConfigTransformer {
             $scoped  = $this->scoped_constants( $content );
         }
 
+        $skipped = [];
+
         foreach ( $constants as $constant ) {
             // Same protection get()/set() apply: the Config Manager never removes a
             // blacklisted (platform-managed) constant, nor one that only exists inside a
             // conditional block it was never able to show the caller.
             if ( ! $this->is_cli && ( $this->is_blacklisted( $constant ) || isset( $scoped[ $constant ] ) ) ) {
+                $skipped[] = $constant;
                 continue;
             }
 
@@ -458,6 +558,12 @@ class WPConfig extends \WPConfigTransformer {
             }
         }
 
-        return [ 'success' => true ];
+        $response = [ 'success' => true ];
+
+        if ( ! empty( $skipped ) ) {
+            $response['skipped'] = $skipped;
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
## Problem

**Manage → Config Manager** shows `WP_REDIS_DISABLED` as an enabled constant on every InstaCache site, so it reads as though the object cache is switched off. It isn't — `v-instawp-cache-enable` writes that define **inside a CLI guard**:

```php
if ( defined( 'WP_CLI' ) && WP_CLI ) {
    define( 'WP_REDIS_DISABLED', true );
}
```

#21 hid this particular constant by blacklisting the `WP_REDIS_` prefix, but that only patched one family. The underlying defect is the parse: `WPConfigTransformer::parse_wp_config()` is a **flat regex over the file text with no awareness of enclosing scope**, so *any* `define()` nested in a block — a conditional, a `switch` case, a function body — is reported exactly like a top-level one.

That is wrong twice over:
1. **Read** — the app advertises a value that does not apply to ordinary web requests.
2. **Write** — Config Manager sends the whole map back on save, so `update()` rewrites a define **inside a branch the caller was never shown**.

## Fix

Walk the token stream (`token_get_all`) and collect the constants that are not effectively unconditional; skip them on the non-CLI path in `get()`, `set()` and `delete()`.

- A define wrapped only in a guard naming the constant itself — the ordinary `if ( ! defined( 'FOO' ) ) { define( 'FOO', … ); }` idiom — is unconditional in effect and **stays manageable**, so hosts that write guarded constants don't lose Config Manager.
- `is_cli` (migration / WP-CLI) sees everything, unchanged.
- No tokenizer extension ⇒ nothing is filtered, i.e. today's behaviour.
- Also: `delete()` now honours the blacklist, which it did not check at all — the DELETE route could remove `DB_NAME`. The app never calls that route (verified in client-app: only GET/POST `v2/manage/configuration`), so this is hardening, not a behaviour change.

Edge cases handled explicitly, because a mis-balanced scan would hide *every* later constant: string-interpolation braces (`"{$x}"`, `"${x}"`), a ternary `:` inside a condition, a function return-type `:`, alternative (`endif;`) syntax, brace-less bodies, and `define` as a method name.

## Verification

Harness wp-config.php with all of the above (script in the PR discussion below).

| constant | in file as | before | after (web) | after (CLI) |
|---|---|---|---|---|
| `WP_DEBUG`, `WP_MEMORY_LIMIT` | top level | shown | shown | shown |
| `WP_CACHE` | `if ( ! defined( 'WP_CACHE' ) )` self-guard | shown | **shown** | shown |
| `DISALLOW_FILE_EDIT` | `defined() or define()` | shown | **shown** | shown |
| `WP_REDIS_DISABLED`, `SOME_CLI_ONLY` | `if ( … WP_CLI )` block | shown | **hidden** | shown |
| `ALT_ONLY` | `if ( … ): … endif;` | shown | **hidden** | shown |
| `TERNARY_SCOPED` | block with a ternary condition | shown | **hidden** | shown |
| `INSIDE_FUNCTION`, `IN_SWITCH` | function body / switch case | shown | **hidden** | shown |
| `AFTER_INTERPOLATION`, `LAST_TOP_LEVEL` | top level, after `"{$prefix}"` | shown | **shown** | shown |

Write path, saving `WP_REDIS_DISABLED=false, IN_SWITCH='hacked', WP_CACHE=false, WP_DEBUG=true, BRAND_NEW='added'`:

| | before | after |
|---|---|---|
| `WP_REDIS_DISABLED` (CLI block) | rewritten to `false` | **untouched (`true`)** |
| `IN_SWITCH` (switch case) | rewritten to `'hacked'` | **untouched (`'nope'`)** |
| `WP_CACHE` (self-guard) | `false` | `false` |
| `WP_DEBUG` (top level) | `true` | `true` |
| `BRAND_NEW` (new) | added | added |

Resulting wp-config.php passes `php -l` and the CLI guard block is intact in both runs.

## Shipping

Consumed by `instawp-connect` via a vendored copy — InstaWP/instawp-connect#526 currently bumps that vendor to `379737f` (the #21 blacklist, merged 2026-07-31 but never vendored, so no site has it). Once this merges I'll re-point #526 at the new `main` so one plugin release carries both.

— Engineer (agent-os)
Agent OS session: https://aos.agents.instawp.net/#/sessions/aos-ses_64627fa0729cb643